### PR TITLE
Migrate News Caching from Redis to PostgreSQL using Prisma

### DIFF
--- a/prisma/migrations/20250611162410_add_news_cache_table/migration.sql
+++ b/prisma/migrations/20250611162410_add_news_cache_table/migration.sql
@@ -1,0 +1,12 @@
+    -- CreateTable
+    CREATE TABLE "NewsCache" (
+        "id" TEXT NOT NULL,
+        "key" TEXT NOT NULL,
+        "data" JSONB NOT NULL,
+        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        "expiresAt" TIMESTAMP(3) NOT NULL,
+        CONSTRAINT "NewsCache_pkey" PRIMARY KEY ("id")
+    );
+
+    -- CreateIndex
+    CREATE UNIQUE INDEX "NewsCache_key_key" ON "NewsCache"("key");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -178,12 +178,12 @@ model Invoice {
 }
 
 model News {
-  id      String   @id @default(uuid())
-  title   String
-  content String
-  date    DateTime
+  id                String   @id @default(uuid())
+  title             String
+  content           String
+  date              DateTime
   matchedCategories String
-  url     String
+  url               String
 
   @@map("news")
 }
@@ -215,4 +215,12 @@ model SummarizedNews {
   url          String
 
   @@map("summarized_news")
+}
+
+model NewsCache {
+  id        String   @id @default(cuid())
+  key       String   @unique
+  data      Json
+  createdAt DateTime @default(now())
+  expiresAt DateTime
 }


### PR DESCRIPTION
- Introduced NewsCache Model: New Prisma model for PostgreSQL-based caching.
- Refactored Caching Logic: Updated loadNewsData and processAllNews functions to use NewsCache table.
- Database Migration Resolution: Addressed and resolved historical migration conflicts to enable smooth deployment of the new caching table.